### PR TITLE
resource_lat: Print message when no destroy handles are found

### DIFF
--- a/resource_lat.c
+++ b/resource_lat.c
@@ -1021,6 +1021,11 @@ static void free_resources_ioctl(const struct run_ctx *ctx, struct thread_ctx *t
 		return;
 	}
 
+	if (ret_count == 0) {
+		printf("%s no handles\n", __func__);
+		return;
+	}
+
 	for (i = 0; i < ret_count; i++) {
 		start_statistics(&stat);
 		switch (type) {


### PR DESCRIPTION
If there is a mismatch in the object types handled by the
resource_lat and the object types defined by the kernel,
rdma_core_get_obj_handles might return zero object.
Check for this and print and error messages so that the
user is notified of the issue.